### PR TITLE
pull request API

### DIFF
--- a/docs/pull_requests.rst
+++ b/docs/pull_requests.rst
@@ -1,0 +1,33 @@
+.. _Pull Requests service:
+
+Pull Requests service
+=====================
+
+**Example**::
+
+    from pygithub3 import Github
+
+    gh = Github()
+
+    pull_requests = gh.pull_requests.list().all()
+    for pr in pull_requests:
+        commits = gh.pull_requests.list_commits(pr.number).all()
+
+Pull Requests
+-------------
+
+.. autoclass:: pygithub3.services.pull_requests.PullRequests
+    :members:
+
+    .. attribute:: comments
+
+        :ref:`Pull Request Comments service`
+
+
+.. _Pull Request Comments service:
+
+Pull Request Comments
+---------------------
+
+.. autoclass:: pygithub3.services.pull_requests.Comments
+    :members:

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -72,5 +72,6 @@ List of services
     users
     repos
     gists
+    pull_requests
 
 .. _mimetypes: http://developer.github.com/v3/mime

--- a/pygithub3/core/client.py
+++ b/pygithub3/core/client.py
@@ -81,7 +81,7 @@ class Client(object):
 
     def get(self, request, **kwargs):
         response = self.request('get', request, **kwargs)
-        assert response.status_code == 200
+        # there are valid GET responses that != 200
         return response
 
     def post(self, request, **kwargs):

--- a/pygithub3/exceptions.py
+++ b/pygithub3/exceptions.py
@@ -8,7 +8,7 @@ class InvalidBodySchema(Exception):
     pass
 
 
-class DoesNotExists(Exception):
+class RequestDoesNotExist(Exception):
     """ Raised when `Request` factory can't find the subclass """
     pass
 

--- a/pygithub3/exceptions.py
+++ b/pygithub3/exceptions.py
@@ -37,6 +37,6 @@ class UnprocessableEntity(Exception):
 class NotFound(Exception):
     """ Raised when server response is 404
 
-    Catched with a pygithub3-exception to `services.base.Service._bool` method
+    Caught with a pygithub3-exception to `services.base.Service._bool` method
     """
     pass

--- a/pygithub3/github.py
+++ b/pygithub3/github.py
@@ -53,6 +53,6 @@ class Github(object):
     @property
     def pull_requests(self):
         """
-        :ref:`Pull Requests service <Pull Requests service`
+        :ref:`Pull Requests service <Pull Requests service>`
         """
         return self._pull_requests

--- a/pygithub3/github.py
+++ b/pygithub3/github.py
@@ -17,9 +17,11 @@ class Github(object):
         from pygithub3.services.users import User
         from pygithub3.services.repos import Repo
         from pygithub3.services.gists import Gist
+        from pygithub3.services.pull_requests import PullRequests
         self._users = User(**config)
         self._repos = Repo(**config)
         self._gists = Gist(**config)
+        self._pull_requests = PullRequests(**config)
 
     @property
     def remaining_requests(self):
@@ -47,3 +49,10 @@ class Github(object):
         :ref:`Gists service <Gists service>`
         """
         return self._gists
+
+    @property
+    def pull_requests(self):
+        """
+        :ref:`Pull Requests service <Pull Requests service`
+        """
+        return self._pull_requests

--- a/pygithub3/requests/base.py
+++ b/pygithub3/requests/base.py
@@ -7,8 +7,8 @@ try:
 except ImportError:
     import json
 
-from pygithub3.exceptions import (DoesNotExists, UriInvalid, ValidationError,
-                                  InvalidBodySchema)
+from pygithub3.exceptions import (RequestDoesNotExist, UriInvalid,
+                                  ValidationError, InvalidBodySchema)
 from pygithub3.resources.base import Raw
 from pygithub3.core.utils import import_module
 
@@ -126,11 +126,11 @@ class Factory(object):
                                         % (ABS_IMPORT_PREFIX, module_chunk))
                 request = getattr(module, request_chunk)
             except ImportError:
-                raise DoesNotExists("'%s' module does not exists"
-                                       % module_chunk)
+                raise RequestDoesNotExist("'%s' module does not exist"
+                                          % module_chunk)
             except AttributeError:
-                raise DoesNotExists(
-                    "'%s' request doesn't exists into '%s' module"
+                raise RequestDoesNotExist(
+                    "'%s' request does not exist in '%s' module"
                     % (request_chunk, module_chunk))
             return func(self, request, **kwargs)
         return wrapper

--- a/pygithub3/requests/pull_requests/__init__.py
+++ b/pygithub3/requests/pull_requests/__init__.py
@@ -1,0 +1,62 @@
+from pygithub3.requests.base import Request, ValidationError
+from pygithub3.resources.base import Raw
+from pygithub3.resources.pull_requests import PullRequest, File
+from pygithub3.resources.repos import Commit
+
+
+class List(Request):
+    uri = 'repos/{user}/{repo}/pulls'
+    resource = PullRequest
+
+
+class Get(Request):
+    uri = 'repos/{user}/{repo}/pulls/{number}'
+    resource = PullRequest
+
+
+class Create(Request):
+    uri = 'repos/{user}/{repo}/pulls'
+    resource = PullRequest
+    body_schema = {
+        'schema': ('title', 'body', 'base', 'head', 'issue'),
+        'required': ('base', 'head'),
+    }
+
+    def validate_body(self, parsed):
+        if (not ('title' in parsed and 'body' in parsed) and
+            not 'issue' in parsed):
+            raise ValidationError('pull request creation requires either an '
+                                  'issue number or a title and body')
+
+class Update(Request):
+    uri = 'repos/{user}/{repo}/pulls/{number}'
+    resource = PullRequest
+    body_schema = {
+        'schema': ('title', 'body', 'state'),
+        'required': (),
+    }
+
+    def validate_body(self, body):
+        if 'state' in body and body['state'] not in ['open', 'closed']:
+            raise ValidationError('If a state is specified, it must be one '
+                                  'of "open" or "closed"')
+
+
+class List_commits(Request):
+    uri = 'repos/{user}/{repo}/pulls/{number}/commits'
+    resource = Commit
+
+
+class List_files(Request):
+    uri = 'repos/{user}/{repo}/pulls/{number}/files'
+    resource = File
+
+
+class Merge_status(Request):
+    uri = 'repos/{user}/{repo}/pulls/{number}/merge'
+    resource = Raw
+
+
+class Merge(Request):
+    uri = 'repos/{user}/{repo}/pulls/{number}/merge'
+    resource = Raw

--- a/pygithub3/requests/pull_requests/__init__.py
+++ b/pygithub3/requests/pull_requests/__init__.py
@@ -60,3 +60,7 @@ class Merge_status(Request):
 class Merge(Request):
     uri = 'repos/{user}/{repo}/pulls/{number}/merge'
     resource = Raw
+    body_schema = {
+        'schema': ('commit_message',),
+        'required': (),
+    }

--- a/pygithub3/requests/pull_requests/comments.py
+++ b/pygithub3/requests/pull_requests/comments.py
@@ -1,0 +1,43 @@
+from pygithub3.requests.base import Request
+from pygithub3.resources.pull_requests import Comment
+
+
+class List(Request):
+    uri = 'repos/{user}/{repo}/pulls/{number}/comments'
+    resource = Comment
+
+
+class Get(Request):
+    uri = 'repos/{user}/{repo}/pulls/comments/{number}'
+    resource = Comment
+
+
+class Create(Request):
+    uri = 'repos/{user}/{repo}/pulls/{number}/comments'
+    resource = Comment
+    body_schema = {
+        'schema': ('body', 'commit_id', 'path', 'position', 'in_reply_to'),
+        'required': ('body',),
+    }
+
+    def validate_body(self, body):
+        if (not ('commit_id' in body and
+                 'path' in body and
+                 'position' in body) and
+            not 'in_reply_to' in body):
+            raise ValidationError('supply either in_reply_to or commit_id, '
+                                  'path, and position')
+
+
+class Edit(Request):
+    uri = 'repos/{user}/{repo}/pulls/comments/{number}'
+    resource = Comment
+    body_schema = {
+        'schema': ('body',),
+        'required': ('body',),
+    }
+
+
+class Delete(Request):
+    uri = 'repos/{user}/{repo}/pulls/comments/{number}'
+    resource = Comment

--- a/pygithub3/resources/pull_requests.py
+++ b/pygithub3/resources/pull_requests.py
@@ -1,0 +1,20 @@
+from .base import Resource
+
+
+class PullRequest(Resource):
+    _dates = ('created_at', 'updated_at', 'closed_at', 'merged_at')
+
+    def __str__(self):
+        return '<PullRequest (%s)>' % getattr(self, 'title', '')
+
+
+class File(Resource):
+    def __str__(self):
+        return '<File (%s)>' % getattr(self, 'filename', '')
+
+
+class Comment(Resource):
+    _dates = ('created_at', 'updated_at')
+
+    def __str__(self):
+        return '<Comment (#%s)>' % getattr(self, 'id', '')

--- a/pygithub3/services/pull_requests/__init__.py
+++ b/pygithub3/services/pull_requests/__init__.py
@@ -120,10 +120,12 @@ class PullRequests(Service, MimeTypeMixin):
         :param str user: Username
         :param str repo: Repository
 
+        This currently raises an HTTP 405 error if the request is not
+        mergable.
+
         """
-        # so, the API docs don't actually say what the status code will be in
-        # the case of a merge failure. I hope it's not a 404.
+        body = {'commit_message': message}
         return self._put(
             self.make_request('pull_requests.merge', number=number,
-                              message=message, user=user, repo=repo)
+                              body=body, user=user, repo=repo)
         )

--- a/pygithub3/services/pull_requests/__init__.py
+++ b/pygithub3/services/pull_requests/__init__.py
@@ -95,23 +95,10 @@ class PullRequests(Service, MimeTypeMixin):
         :param str repo: Repository
 
         """
-        # for this to work with a proper Resource, we would need to pass the
-        # response's status code to the Resource constructor, and that's kind
-        # of scary
-        try:
-            resp = self._client.get(
-                self.make_request('pull_requests.merge_status', number=number,
-                                user=user, repo=repo)
-            )
-        except NotFound:
-            return False
-        code = resp.status_code
-        if code == 204:
-            return True
-        # TODO: more flexible way to return arbitrary objects based on
-        # response.  Probably something on Request
-        raise BadRequest('got code %s: %s' % (code, resp.content))
-        # again, I'm sorry.
+        return self._bool(
+            self.make_request('pull_requests.merge_status', number=number,
+                              user=user, repo=repo)
+        )
 
     def merge(self, number, message='', user=None, repo=None):
         """Merge a pull request.

--- a/pygithub3/services/pull_requests/__init__.py
+++ b/pygithub3/services/pull_requests/__init__.py
@@ -1,0 +1,129 @@
+from pygithub3.exceptions import BadRequest, NotFound
+from pygithub3.services.base import Service, MimeTypeMixin
+from .comments import Comments
+
+
+class PullRequests(Service, MimeTypeMixin):
+    """Consume `Pull Request API <http://developer.github.com/v3/pulls/>`_"""
+
+    def __init__(self, **config):
+        self.comments = Comments(**config)
+        super(PullRequests, self).__init__(**config)
+
+    def list(self, user=None, repo=None):
+        """List all of the pull requests for a repo
+
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._get_result(
+            self.make_request('pull_requests.list', user=user, repo=repo)
+        )
+
+    def get(self, number, user=None, repo=None):
+        """Get a single pull request
+
+        :param str number: The number of the pull request to get
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._get(
+            self.make_request('pull_requests.get', number=number, user=user,
+                              repo=repo)
+        )
+
+    def create(self, body, user=None, repo=None):
+        """Create a pull request
+
+        :param dict body: Data for the new pull request
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._post(
+            self.make_request('pull_requests.create', body=body, user=user,
+                              repo=repo)
+        )
+
+    def update(self, number, body, user=None, repo=None):
+        """Update a pull request
+
+        :param str number: The number of the the pull request to update
+        :param dict body: The data to update the pull request with
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._patch(
+            self.make_request('pull_requests.update', number=number,
+                              body=body, user=user, repo=repo)
+        )
+
+    def list_commits(self, number, user=None, repo=None):
+        """List the commits for a pull request
+
+        :param str number: The number of the pull request to list commits for
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._get_result(
+            self.make_request('pull_requests.list_commits', number=number,
+                              user=user, repo=repo)
+        )
+
+    def list_files(self, number, user=None, repo=None):
+        """List the files for a pull request
+
+        :param str number: The number of the pull request to list files for
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._get_result(
+            self.make_request('pull_requests.list_files', number=number,
+                              user=user, repo=repo)
+        )
+
+    def merge_status(self, number, user=None, repo=None):
+        """Gets whether a pull request has been merged or not.
+
+        :param str number: The pull request to check
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        # for this to work with a proper Resource, we would need to pass the
+        # response's status code to the Resource constructor, and that's kind
+        # of scary
+        try:
+            resp = self._client.get(
+                self.make_request('pull_requests.merge_status', number=number,
+                                user=user, repo=repo)
+            )
+        except NotFound:
+            return False
+        code = resp.status_code
+        if code == 204:
+            return True
+        # TODO: more flexible way to return arbitrary objects based on
+        # response.  Probably something on Request
+        raise BadRequest('got code %s: %s' % (code, resp.content))
+        # again, I'm sorry.
+
+    def merge(self, number, message='', user=None, repo=None):
+        """Merge a pull request.
+
+        :param str number: The pull request to merge
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        # so, the API docs don't actually say what the status code will be in
+        # the case of a merge failure. I hope it's not a 404.
+        return self._put(
+            self.make_request('pull_requests.merge', number=number,
+                              message=message, user=user, repo=repo)
+        )

--- a/pygithub3/services/pull_requests/comments.py
+++ b/pygithub3/services/pull_requests/comments.py
@@ -1,0 +1,73 @@
+from pygithub3.services.base import Service, MimeTypeMixin
+
+
+class Comments(Service, MimeTypeMixin):
+    """Consume `Review Comments API
+    <http://developer.github.com/v3/pulls/comments/>`_
+
+    """
+
+    def list(self, number, user=None, repo=None):
+        """List all the comments for a pull request
+
+        :param str number: The number of the pull request
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._get_result(
+            self.make_request('pull_requests.comments.list', number=number,
+                              user=user, repo=repo)
+        )
+
+    def get(self, number, user=None, repo=None):
+        """Get a single comment
+
+        :param str number: The comment to get
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._get(
+            self.make_request('pull_requests.comments.get', number=number,
+                              user=user, repo=repo)
+        )
+
+    def create(self, number, body, user=None, repo=None):
+        """Create a comment
+
+        :param str number: the pull request to comment on
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._post(
+            self.make_request('pull_requests.comments.create', number=number,
+                              body=body, user=user, repo=repo)
+        )
+
+    def edit(self, number, body, user=None, repo=None):
+        """Edit a comment
+
+        :param str number: The id of the comment to edit
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._patch(
+            self.make_request('pull_requests.comments.edit', number=number,
+                              body=body, user=user, repo=repo)
+        )
+
+    def delete(self, number, user=None, repo=None):
+        """Delete a comment
+
+        :param str number: The comment to delete
+        :param str user: Username
+        :param str repo: Repository
+
+        """
+        return self._delete(
+            self.make_request('pull_requests.comments.delete', number=number,
+                              user=user, repo=repo)
+        )

--- a/pygithub3/tests/requests/test_core.py
+++ b/pygithub3/tests/requests/test_core.py
@@ -2,12 +2,14 @@
 # -*- encoding: utf-8 -*-
 
 from mock import Mock
+from nose.tools import raises
 
 from pygithub3.tests.utils.core import TestCase
 from pygithub3.requests.base import Factory, Body, json, Request
 from pygithub3.exceptions import (UriInvalid, DoesNotExists, ValidationError,
                                   InvalidBodySchema)
-from pygithub3.tests.utils.base import mock_json, DummyRequest
+from pygithub3.tests.utils.base import (mock_json, DummyRequest,
+                                        DummyRequestValidation)
 from pygithub3.tests.utils.requests import (
     RequestWithArgs, RequestCleanedUri, RequestBodyInvalidSchema,
     RequestCleanedBody)
@@ -74,7 +76,7 @@ class TestRequestBodyWithSchema(TestCase):
 
     def setUp(self):
         valid_body = dict(schema=('arg1', 'arg2'), required=('arg1', ))
-        self.b = Body({}, **valid_body)
+        self.b = Body({}, valid_body)
 
     def test_with_body_empty_and_schema_permissive(self):
         self.b.schema = ('arg1', 'arg2', '...')
@@ -100,3 +102,14 @@ class TestRequestBodyWithSchema(TestCase):
     def test_only_valid_keys(self):
         self.b.content = dict(arg1='arg1', arg2='arg2', fake='test')
         self.assertEqual(self.b.dumps(), dict(arg1='arg1', arg2='arg2'))
+
+
+class TestBodyValidation(TestCase):
+    @raises(ValidationError)
+    def test_with_error(self):
+        req = DummyRequestValidation(
+            body={'foo': 'bar', 'error': 'yes'},
+        )
+        req.body_schema = {'schema': ('foo',),
+                           'required': ('foo',)}
+        req.get_body()

--- a/pygithub3/tests/requests/test_core.py
+++ b/pygithub3/tests/requests/test_core.py
@@ -6,8 +6,8 @@ from nose.tools import raises
 
 from pygithub3.tests.utils.core import TestCase
 from pygithub3.requests.base import Factory, Body, json, Request
-from pygithub3.exceptions import (UriInvalid, DoesNotExists, ValidationError,
-                                  InvalidBodySchema)
+from pygithub3.exceptions import (UriInvalid, RequestDoesNotExist,
+                                  ValidationError, InvalidBodySchema)
 from pygithub3.tests.utils.base import (mock_json, DummyRequest,
                                         DummyRequestValidation)
 from pygithub3.tests.utils.requests import (
@@ -29,8 +29,8 @@ class TestFactory(TestCase):
         self.assertRaises(UriInvalid, self.f, '.invalid')
 
     def test_BUILDER_with_fake_action(self):
-        self.assertRaises(DoesNotExists, self.f, 'users.fake')
-        self.assertRaises(DoesNotExists, self.f, 'fake.users')
+        self.assertRaises(RequestDoesNotExist, self.f, 'users.fake')
+        self.assertRaises(RequestDoesNotExist, self.f, 'fake.users')
 
     def test_BUILDER_builds_users(self):
         """ Users.get as real test because it wouldn't be useful mock

--- a/pygithub3/tests/services/test_pull_requests.py
+++ b/pygithub3/tests/services/test_pull_requests.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+import requests
+from mock import patch, Mock
+from nose.tools import raises
+
+from pygithub3.tests.utils.core import TestCase
+from pygithub3.services.pull_requests import PullRequests, Comments
+from pygithub3.resources.base import json
+from pygithub3.requests.base import ValidationError
+from pygithub3.tests.utils.base import (mock_response, mock_response_result,
+                                        mock_json)
+from pygithub3.tests.utils.services import _
+
+
+json.dumps = Mock(side_effect=mock_json)
+json.loads = Mock(side_effect=mock_json)
+
+
+@patch.object(requests.sessions.Session, 'request')
+class TestPullRequestsService(TestCase):
+    def setUp(self):
+        self.service = PullRequests(user='user', repo='repo')
+
+    def test_LIST(self, reqm):
+        reqm.return_value = mock_response_result()
+        self.service.list().all()
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls'))
+        )
+
+    def test_GET(self, reqm):
+        reqm.return_value = mock_response()
+        self.service.get(123)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls/123'))
+        )
+
+    def test_CREATE_with_title_and_body(self, reqm):
+        reqm.return_value = mock_response('post')
+        data = {
+            'title': 'this is a pull request',
+            'body': 'merge me!',
+            'head': 'octocat:some-feature',
+            'base': 'master',
+        }
+        self.service.create(data)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('post', _('repos/user/repo/pulls'))
+        )
+
+    def test_CREATE_with_issue(self, reqm):
+        reqm.return_value = mock_response('post')
+        data = {
+            'issue': 1,
+            'head': 'octocat:some-feature',
+            'base': 'master',
+        }
+        self.service.create(data)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('post', _('repos/user/repo/pulls'))
+        )
+
+    @raises(ValidationError)
+    def test_CREATE_with_no_title(self, reqm):
+        reqm.return_value = mock_response('post')
+        data = {
+            'body': 'merge me!',
+            'head': 'octocat:some-feature',
+            'base': 'master',
+        }
+        self.service.create(data)
+
+    def test_UPDATE(self, reqm):
+        reqm.return_value = mock_response('patch')
+        data = {}
+        self.service.update(123, data)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('patch', _('repos/user/repo/pulls/123'))
+        )
+
+    @raises(ValidationError)
+    def test_UPDATE_with_invalid_state(self, reqm):
+        reqm.return_value = mock_response('patch')
+        data = {'state': 'Illinois'}
+        self.service.update(123, data)
+
+    def test_LIST_COMMITS(self, reqm):
+        reqm.return_value = mock_response_result('get')
+        self.service.list_commits(123).all()
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls/123/commits'))
+        )
+
+    def test_LIST_FILES(self, reqm):
+        reqm.return_value = mock_response_result('get')
+        self.service.list_files(123).all()
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls/123/files'))
+        )
+
+    def test_MERGE_STATUS_true(self, reqm):
+        reqm.return_value = mock_response(204)
+        resp = self.service.merge_status(123)
+        self.assertEqual(True, resp)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls/123/merge'))
+        )
+
+    def test_MERGE_STATUS_false(self, reqm):
+        reqm.return_value = mock_response(404)
+        resp = self.service.merge_status(123)
+        self.assertEqual(False, resp)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls/123/merge'))
+        )
+
+    def test_MERGE(self, reqm):
+        reqm.return_value = mock_response(200)
+        self.service.merge(123, 'merging this')
+        self.assertEqual(
+            reqm.call_args[0],
+            ('put', _('repos/user/repo/pulls/123/merge'))
+        )
+
+
+@patch.object(requests.sessions.Session, 'request')
+class TestPullRequestCommentsService(TestCase):
+    def setUp(self):
+        self.service = Comments(user='user', repo='repo')
+
+    def test_LIST(self, reqm):
+        reqm.return_value = mock_response_result(200)
+        self.service.list(123).all()
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls/123/comments'))
+        )
+
+    def test_GET(self, reqm):
+        reqm.return_value = mock_response(200)
+        self.service.get(1)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls/comments/1'))
+        )
+
+    def test_CREATE(self, reqm):
+        reqm.return_value = mock_response(201)
+        data = {
+            'body': ':sparkles:',
+            'commit_id': 'abc123',
+            'path': 'foo.txt',
+            'position': '2',
+        }
+        self.service.create(1, data)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('post', _('repos/user/repo/pulls/1/comments'))
+        )
+
+    def test_CREATE_in_reply_to(self, reqm):
+        reqm.return_value = mock_response(201)
+        data = {
+            'body': ':sparkles:',
+            'in_reply_to': '5',
+        }
+        self.service.create(1, data)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('post', _('repos/user/repo/pulls/1/comments'))
+        )
+
+    def test_EDIT(self, reqm):
+        reqm.return_value = mock_response(200)
+        data = {
+            'body': 'something completely different',
+        }
+        self.service.edit(1, data)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('patch', _('repos/user/repo/pulls/comments/1'))
+        )
+
+    def test_DELETE(self, reqm):
+        reqm.return_value = mock_response(204)
+        self.service.delete(1)
+        self.assertEqual(
+            reqm.call_args[0],
+            ('delete', _('repos/user/repo/pulls/comments/1'))
+        )

--- a/pygithub3/tests/services/test_pull_requests.py
+++ b/pygithub3/tests/services/test_pull_requests.py
@@ -113,7 +113,7 @@ class TestPullRequestsService(TestCase):
         self.assertEqual(True, resp)
         self.assertEqual(
             reqm.call_args[0],
-            ('get', _('repos/user/repo/pulls/123/merge'))
+            ('head', _('repos/user/repo/pulls/123/merge'))
         )
 
     def test_MERGE_STATUS_false(self, reqm):
@@ -122,7 +122,7 @@ class TestPullRequestsService(TestCase):
         self.assertEqual(False, resp)
         self.assertEqual(
             reqm.call_args[0],
-            ('get', _('repos/user/repo/pulls/123/merge'))
+            ('head', _('repos/user/repo/pulls/123/merge'))
         )
 
     def test_MERGE(self, reqm):

--- a/pygithub3/tests/utils/base.py
+++ b/pygithub3/tests/utils/base.py
@@ -4,7 +4,7 @@
 from mock import Mock
 
 from pygithub3.resources.base import Resource
-from pygithub3.requests.base import Request
+from pygithub3.requests.base import Request, ValidationError
 
 
 def mock_json(content):
@@ -37,3 +37,14 @@ DummyResource.loads = Mock(side_effect=loads_mock)
 class DummyRequest(Request):
     uri = 'dummyrequest'
     resource = DummyResource
+
+
+class DummyRequestValidation(DummyRequest):
+    body_schema = {
+        'schema': ('foo', 'error'),
+        'required': ('foo',)
+    }
+
+    def validate_body(self, body):
+        if body.get('error') == 'yes':
+            raise ValidationError('yes')

--- a/pygithub3/tests/utils/base.py
+++ b/pygithub3/tests/utils/base.py
@@ -14,7 +14,7 @@ def mock_json(content):
 def mock_response(status_code='get', content={}):
     CODES = dict(get=200, patch=200, post=201, delete=204)
     response = Mock(name='response')
-    response.status_code = CODES[str(status_code).lower()] or status_code
+    response.status_code = CODES.get(str(status_code).lower(), status_code)
     response.content = content
     return response
 


### PR DESCRIPTION
This implements github's [Pull Request API](http://developer.github.com/v3/pulls/).

I also did a little bit of internals work to support methods with slightly more complex validations. You can now define a `validate_body()` method on Request classes. It is still only called if that Request defines a schema, and is called before the required attributes are checked.
