### PR TITLE
Require a current version of `requests` -- `pygithub3` installs, but lat...

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-requests
+requests >= 0.12.1


### PR DESCRIPTION
...er fails with all sorts of cryptic errors if you have an older, pre-existing version of `requests` installed when you install `pygithub3`.
