### PR TITLE
Add travis-ci.org configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+install:
+  - pip install -r requirements/dev.txt --use-mirrors
+script: nosetests


### PR DESCRIPTION
A simple patch to add support for Travis CI.  Just follow getting started guide[1] to enable it.

[1] http://about.travis-ci.org/docs/user/getting-started/

Signed-off-by: Paul Belanger paul.belanger@polybeacon.com
