### PR TITLE
Allow you to set a timeout for the Github client

### DIFF
--- a/pygithub3/core/client.py
+++ b/pygithub3/core/client.py
@@ -56,6 +56,8 @@ class Client(object):
         self.requester.params.append(per_page)
         if config.get('verbose'):
             self.requester.config = {'verbose': config['verbose']}
+        if config.get('timeout'):
+            self.requester.timeout = config['timeout']
 
     def __parse_kwargs(func):
         """ Decorator to put extra args into requests.params """

--- a/pygithub3/services/base.py
+++ b/pygithub3/services/base.py
@@ -18,6 +18,7 @@ class Service(object):
     :param int per_page: Items in each page of multiple returns
     :param str base_url: To support another github-related API (untested)
     :param stream verbose: Stream to write debug logs
+    :param timeout float: Timeout for requests
 
     You can configure the **authentication** with BasicAuthentication (login
     and password) and with `OAuth <http://developer.github.com/v3/oauth/>`_ (


### PR DESCRIPTION
Simple change, basically lets you pass in a timeout for the client so every service will timeout after a certain time. So you end up with something like this:

``` python
gh = Github(token=gh_token, timeout=10, ...)
```
