### PR TITLE
Statuses API Service

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,3 +31,4 @@ Patches and Suggestions
 - Ralph Bean <rbean@redhat.com>
 - Jason A. Donenfeld <Jason@zx2c4.com>
 - Brad Montgomery <http://about.me/bkmontgomery>
+- Jonas Baumann <https://github.com/jone>

--- a/docs/repos.rst
+++ b/docs/repos.rst
@@ -136,6 +136,12 @@ Hooks
 .. autoclass:: pygithub3.services.repos.Hooks
     :members:
 
+Statuses
+---------
+
+.. autoclass:: pygithub3.services.repos.Statuses
+    :members:
+
 .. _github repos doc: http://developer.github.com/v3/repos
 .. _github collaborators doc: http://developer.github.com/v3/repos/collaborators
 .. _github commits doc: http://developer.github.com/v3/repos/commits
@@ -144,3 +150,4 @@ Hooks
 .. _github keys doc: http://developer.github.com/v3/repos/keys
 .. _github watching doc: http://developer.github.com/v3/repos/watching
 .. _github hooks doc: http://developer.github.com/v3/repos/hooks
+.. _github statuses doc: http://developer.github.com/v3/repos/statuses

--- a/pygithub3/requests/repos/statuses.py
+++ b/pygithub3/requests/repos/statuses.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+from . import Request
+
+from pygithub3.resources.repos import Status
+
+
+class List(Request):
+
+    uri = 'repos/{user}/{repo}/statuses/{sha}'
+    resource = Status
+
+
+class Create(Request):
+
+    uri = '/repos/{user}/{repo}/statuses/{sha}'
+    resource = Status
+    body_schema = {
+        'schema': ('state', 'target_url', 'description'),
+        'required': ('state',)}

--- a/pygithub3/resources/repos.py
+++ b/pygithub3/resources/repos.py
@@ -115,3 +115,12 @@ class Hook(Resource):
 
     def __str__(self):
         return '<Hook (%s)>' % getattr(self, 'name', '')
+
+
+class Status(Resource):
+
+    _dates = ('created_at', 'updated_at')
+    _maps = {'creator': User}
+
+    def __str__(self):
+        return '<Status (%s)>' % getattr(self, 'state', '')

--- a/pygithub3/services/repos/__init__.py
+++ b/pygithub3/services/repos/__init__.py
@@ -8,6 +8,7 @@ from .forks import Forks
 from .keys import Keys
 from .watchers import Watchers
 from .hooks import Hooks
+from .statuses import Statuses
 
 
 class Repo(Service):
@@ -21,6 +22,7 @@ class Repo(Service):
         self.keys = Keys(**config)
         self.watchers = Watchers(**config)
         self.hooks = Hooks(**config)
+        self.statuses = Statuses(**config)
         super(Repo, self).__init__(**config)
 
     def list(self, user=None, type='all', sort='full_name', direction='desc'):

--- a/pygithub3/services/repos/statuses.py
+++ b/pygithub3/services/repos/statuses.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+from . import Service
+
+
+class Statuses(Service):
+    """ Consume `Repo Statuses API
+    <http://developer.github.com/v3/repos/statuses>`_ """
+
+    def list(self, sha=None, user=None, repo=None):
+        """ Get repository's collaborators
+
+        :param str sha: Commit's sha
+        :param str user: Username
+        :param str repo: Repository
+        :returns: A :doc:`result`
+
+        .. note::
+            Remember :ref:`config precedence`
+        """
+
+        request = self.make_request('repos.statuses.list',
+                                    sha=sha, user=user, repo=repo)
+        return self._get_result(request)
+
+    def create(self, data, sha, user=None, repo=None):
+        """ Create a status
+
+        :param dict data: Input. See `github statuses doc`_
+        :param str sha: Commit's sha
+        :param str user: Username
+        :param str repo: Repository
+
+        .. note::
+            Remember :ref:`config precedence`
+
+        .. warning::
+            You must be authenticated
+
+        ::
+
+            data = {
+              "state": "success",
+              "target_url": "https://example.com/build/status",
+              "description": "The build succeeded!"
+            }
+            statuses_service.create(data, '6dcb09', user='octocat',
+                repo='oct_repo')
+        """
+
+        request = self.make_request('repos.statuses.create',
+                                    sha=sha, user=user, repo=repo, body=data)
+        return self._post(request)

--- a/pygithub3/tests/services/test_repos.py
+++ b/pygithub3/tests/services/test_repos.py
@@ -4,7 +4,7 @@ import requests
 from mock import patch
 
 from pygithub3.services.repos import (Repo, Collaborators, Commits, Downloads,
-    Forks, Keys, Watchers, Hooks)
+    Forks, Keys, Watchers, Hooks, Statuses)
 from pygithub3.tests.utils.base import (dummy_json, mock_response,
     mock_response_result)
 from pygithub3.tests.utils.core import TestCase
@@ -416,3 +416,25 @@ class TestHooksService(TestCase):
         self.hs.delete(1)
         self.assertEqual(request_method.call_args[0],
                 ('delete', _('repos/oct/re_oct/hooks/1')))
+
+@dummy_json
+@patch.object(requests.sessions.Session, 'request')
+class TestStatusesService(TestCase):
+
+    def setUp(self):
+        self.ss = Statuses(user='oct', repo='re_oct')
+
+    def test_LIST(self, request_method):
+        request_method.return_value = mock_response_result()
+        self.ss.list(sha='e3bc').all()
+        self.assertEqual(request_method.call_args[0],
+                         ('get', _('repos/oct/re_oct/statuses/e3bc')))
+
+    def test_CREATE(self, request_method):
+        request_method.return_value = mock_response('post')
+        self.ss.create({"state": "success",
+                        "target_url": "https://example.com/build/status",
+                        "description": "The build succeeded!"},
+                       sha='e3bc')
+        self.assertEqual(request_method.call_args[0],
+                         ('post', _('repos/oct/re_oct/statuses/e3bc')))


### PR DESCRIPTION
Hey there,

I've added support for the [Statuses API](http://developer.github.com/v3/repos/statuses/).
It allows to set the CI build status of a commit, which is then displayed in pull-requests, as travis does it.

I couldn't build the docs because I don't know how - not sure if they look well with my changes.

Great project by the way ;)

Cheers
