### PR TITLE
requests version in requirements/base.txt conflicts with version requests of requests installed before install pygithub3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-requests==0.14.0
+requests>=0.14.0


### PR DESCRIPTION
requests version in requirements/base.txt conflicts with version requests of requests installed before install pygithub3.

This does not create an issue when using in code. But the setuptools implementation of creating CLI tools using entry_points.console_scripts raises an error whenever there is a mismatch between the installed package version and the one required by any other package that the console_script makes use of. Debugging this becomes a pain because setuptools just throws an error about the version mismatch and not the package which requires that particular version.

To my knowledge, this package works fine with the newer version of requests. I did not run tests thought.
