### PR TITLE
Update requests requirement with API changes.

### DIFF
--- a/pygithub3/core/client.py
+++ b/pygithub3/core/client.py
@@ -49,11 +49,10 @@ class Client(object):
 
     def set_token(self, token):
         if token:
-            self.requester.params.append(('access_token', token))
+            self.requester.params['access_token'] = token
 
     def __set_params(self, config):
-        per_page = ('per_page', config.get('per_page'))
-        self.requester.params.append(per_page)
+        self.requester.params['per_page'] = config.get('per_page')
         if config.get('verbose'):
             self.requester.config = {'verbose': config['verbose']}
         if config.get('timeout'):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-requests==0.14.0
+requests>=2.0.0


### PR DESCRIPTION
We're currently having conflicts with the requests requirement because it's pinned to an old version. Tests are passing after making a couple small changes where the requests API has changed.

Related to #33.
