### PR TITLE
Support for requests>0.14

### DIFF
--- a/pygithub3/core/client.py
+++ b/pygithub3/core/client.py
@@ -49,11 +49,10 @@ class Client(object):
 
     def set_token(self, token):
         if token:
-            self.requester.params.append(('access_token', token))
+            self.requester.params['access_token'] = token
 
     def __set_params(self, config):
-        per_page = ('per_page', config.get('per_page'))
-        self.requester.params.append(per_page)
+        self.requester.params['per_page'] = config.get('per_page')
         if config.get('verbose'):
             self.requester.config = {'verbose': config['verbose']}
         if config.get('timeout'):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-requests==0.14.0
+requests>0.14.0


### PR DESCRIPTION
requests 0.14 is too old and it's bad to set version so strictly anyway.
In requests >0.14.0 `self.params` became a dict so I do a few changes and fix dependency version.
I run tests for requests 1.2.3 and requests 2.3.0 and everything seems to be ok.
