### PR TITLE
Revert "An empty string doesn't work around the 411 issue on PUTs. Use '...

### DIFF
--- a/pygithub3/services/base.py
+++ b/pygithub3/services/base.py
@@ -111,10 +111,10 @@ class Service(object):
     def _put(self, request, **kwargs):
         """ Bug in Github API? requests library?
 
-        I must send data when the specifications' of some PUT request are 'Not
-        send input data'. If I don't do that and send data as None, the
-        requests library doesn't send 'Content-length' header and the server
-        returns 411 - Required Content length (at least 0)
+        I must send data as empty string when the specifications' of some PUT
+        request are 'Not send input data'. If I don't do that and send data as
+        None, the requests library doesn't send 'Content-length' header and the
+        server returns 411 - Required Content length (at least 0)
 
         For instance:
             - follow-user request doesn't send input data
@@ -125,7 +125,7 @@ class Service(object):
 
         Related: https://github.com/github/developer.github.com/pull/52
         """
-        input_data = request.get_body() or 'PLACEHOLDER'
+        input_data = request.get_body() or ''
         response = self._client.put(request, data=input_data, **kwargs)
         if response.status_code != 204:  # != NO_CONTENT
             return request.resource.loads(response.content)

--- a/pygithub3/tests/services/test_core.py
+++ b/pygithub3/tests/services/test_core.py
@@ -28,7 +28,7 @@ class TestServiceCalls(TestCase):
 
     def test_PUT(self, request_method):
         self.s._put(self.r, **self.args)
-        data = 'PLACEHOLDER'  # See _put
+        data = ''  # See _put
         request_method.assert_called_with('put', _('dummyrequest'),
                                           data=data, params=self.args)
 


### PR DESCRIPTION
...PLACEHOLDER'"

This reverts commit b488b8447fc943d920cd72b60c6647e5840ff800.

requests now seems to do the right thing (2.3.0).
And GitHub rejects bodies that don't validate as JSON.
