### PR TITLE
Adding team membership endpoints support

### DIFF
--- a/pygithub3/requests/orgs/teams.py
+++ b/pygithub3/requests/orgs/teams.py
@@ -57,6 +57,18 @@ class Remove_member(Request):
     uri = 'teams/{id}/members/{user}'
 
 
+class Has_membership(Request):
+    uri = 'teams/{id}/memberships/{user}'
+
+
+class Add_membership(Request):
+    uri = 'teams/{id}/memberships/{user}'
+
+
+class Remove_membership(Request):
+    uri = 'teams/{id}/memberships/{user}'
+
+
 class List_repos(Request):
     uri = 'teams/{id}/repos'
     resource = Repo

--- a/pygithub3/services/base.py
+++ b/pygithub3/services/base.py
@@ -125,7 +125,7 @@ class Service(object):
 
         Related: https://github.com/github/developer.github.com/pull/52
         """
-        input_data = request.get_body() or 'PLACEHOLDER'
+        input_data = request.get_body() or '{"DUMMY": "PLACEHOLDER"}'
         response = self._client.put(request, data=input_data, **kwargs)
         if response.status_code != 204:  # != NO_CONTENT
             return request.resource.loads(response.content)

--- a/pygithub3/services/orgs/teams.py
+++ b/pygithub3/services/orgs/teams.py
@@ -64,7 +64,7 @@ class Teams(Service):
         return self._get_result(request)
 
     def is_member(self, id, user):
-        """ Determine if user is a member of a team
+        """ Determine if user is a member of a team (deprecated)
 
         :param int id: The team id
         :param str user: User name
@@ -74,7 +74,7 @@ class Teams(Service):
         return self._bool(request)
 
     def add_member(self, id, user):
-        """ Add a user to a team
+        """ Add a user to a team (deprecated)
 
         :param int id: The team id
         :param str user: User name
@@ -84,12 +84,43 @@ class Teams(Service):
         return self._put(request)
 
     def remove_member(self, id, user):
-        """ Remove a member from a team
+        """ Remove a member from a team (deprecated)
 
         :param int id: The team id
         :param str user: User name
         """
         request = self.request_builder('orgs.teams.remove_member',
+                                       id=id, user=user)
+        return self._delete(request)
+
+    def has_membership(self, id, user):
+        """ Determine if user has specified team membership
+
+        :param int id: The team id
+        :param str user: User name
+        :returns: A :doc:`result`
+        """
+        request = self.request_builder('orgs.teams.has_membership',
+                                       id=id, user=user)
+        return self._get(request)
+
+    def add_membership(self, id, user):
+        """ Add a user to a team
+
+        :param int id: The team id
+        :param str user: User name
+        """
+        request = self.request_builder('orgs.teams.add_membership',
+                                       id=id, user=user)
+        return self._put(request)
+
+    def remove_membership(self, id, user):
+        """ Remove a member from a team
+
+        :param int id: The team id
+        :param str user: User name
+        """
+        request = self.request_builder('orgs.teams.remove_membership',
                                        id=id, user=user)
         return self._delete(request)
 

--- a/pygithub3/tests/services/test_core.py
+++ b/pygithub3/tests/services/test_core.py
@@ -28,7 +28,7 @@ class TestServiceCalls(TestCase):
 
     def test_PUT(self, request_method):
         self.s._put(self.r, **self.args)
-        data = 'PLACEHOLDER'  # See _put
+        data = '{"DUMMY": "PLACEHOLDER"}'  # See _put
         request_method.assert_called_with('put', _('dummyrequest'),
                                           data=data, params=self.args)
 


### PR DESCRIPTION
According to GitHub API docs, 'members' endpoint is deprecated and will be removed https://developer.github.com/v3/orgs/teams/#add-team-member

I added implementation for 'memberships' endpoint.
