### PR TITLE
Add missing funcsigs dependency to dev requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@ nose
 mock
 unittest2
 sphinx
+funcsigs


### PR DESCRIPTION
When running `nosetests` on a clean checkout there are errors about missing `funcsigs` dependency:

```
======================================================================
ERROR: Failure: ImportError (No module named funcsigs)
----------------------------------------------------------------------
```
