### PR TITLE
Switch to using modern Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: python
 python:
   - "2.6"


### PR DESCRIPTION
See https://docs.travis-ci.com/user/migrating-from-legacy/ for details, but the modern infrastructure will allow builds to start and complete faster.
