### PR TITLE
Add pull-request list ordering options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build
 dist/
 build/
 *egg-info
+.idea

--- a/pygithub3/services/pull_requests/__init__.py
+++ b/pygithub3/services/pull_requests/__init__.py
@@ -11,20 +11,29 @@ class PullRequests(Service, MimeTypeMixin):
         self.comments = Comments(**config)
         super(PullRequests, self).__init__(**config)
 
-    def list(self, state='open', user=None, repo=None):
+    def list(self, state='open', user=None, repo=None, sort=None, direction=None):
         """List all of the pull requests for a repo
 
-        :param str state: Pull requests state ('open' or 'closed')
+        :param str state: Pull requests state ('open', 'closed', or 'all')
         :param str user: Username
         :param str repo: Repository
+        :param str sort: 'created', 'updated' or 'comments'
+        :param str direction: 'asc' or 'desc'
         :returns: A :doc:`result`
 
         .. note::
             Remember :ref:`config precedence`
         """
+        kwargs = {}
+        if sort is not None:
+            kwargs['sort'] = sort
+        if direction is not None:
+            kwargs['direction'] = direction
+
         return self._get_result(
             self.make_request('pull_requests.list', user=user, repo=repo),
-            state=state
+            state=state,
+            **kwargs
         )
 
     def get(self, number, user=None, repo=None):

--- a/pygithub3/tests/services/test_pull_requests.py
+++ b/pygithub3/tests/services/test_pull_requests.py
@@ -26,6 +26,20 @@ class TestPullRequestsService(TestCase):
             ('get', _('repos/user/repo/pulls'))
         )
 
+    def test_LIST_ordered(self, reqm):
+        reqm.return_value = mock_response_result()
+        order_args = dict(sort='updated', direction='desc')
+        self.service.list(**order_args).all()
+
+        self.assertEqual(
+            reqm.call_args[0],
+            ('get', _('repos/user/repo/pulls'))
+        )
+
+        params = reqm.call_args[1]['params']
+        for key, value in order_args.iteritems():
+            self.assertEqual(params[key], value)
+
     def test_GET(self, reqm):
         reqm.return_value = mock_response()
         self.service.get(123)


### PR DESCRIPTION
This adds 'sort' and 'direction' options to the pull-request
list method as kwargs.  If they aren't passed, default values
are assumed by the API.  See github API docs for more info.
